### PR TITLE
Approve pnpm builds to prevent annoying warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,11 @@
     "@types/pg": "^8.11.11",
     "drizzle-kit": "^0.30.5",
     "tsx": "^4.19.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@scarf/scarf",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
Allow @scarf/scarf and esbuild builds.

```
╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: @scarf/scarf, esbuild.                                            │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```